### PR TITLE
refactor: Split review task into chunks to avoid token limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt-auto-code-review",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "main": "index.js",
   "scripts": {
     "build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ if (gitDetails instanceof Error) {
 job(gitDetails)
   .then((review: string | undefined) => {
     if (!review) {
+      console.log('Review task failed!');
       throw new Error('Review task failed');
     }
 


### PR DESCRIPTION
To accommodate the token limits for various GPT models:
- gpt-35-turbo: 4096 tokens
- gpt-4: 8192 tokens
- gpt-4-32k: 32768 tokens

These limits include tokens from both the message array and model response. The combined token count of the messages array and max_tokens parameter must stay within these limits to avoid errors.

To address this, we:
- Split the diff into separate review requests
- Combine the individual requests into a single review